### PR TITLE
Add IB_DESIGNABLE to ZFCheckbox

### DIFF
--- a/Classes/ZFCheckbox.h
+++ b/Classes/ZFCheckbox.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
+IB_DESIGNABLE
 @interface ZFCheckbox : UIControl
 
 @property (nonatomic) CGFloat lineWidth;


### PR DESCRIPTION
When working with storyboards, IB_DESIGNABLE renders custom views in storyboards. Instead of loading nothing, the initial state of the checkbox is rendered.
